### PR TITLE
[BUG] : Fixing RXHCC coefficient mapping issue

### DIFF
--- a/src/hccinfhir/model_coefficients.py
+++ b/src/hccinfhir/model_coefficients.py
@@ -101,7 +101,11 @@ def apply_coefficients(demographics: Demographics,
 
     # Apply the coefficients
     for hcc in hcc_set:
-        key = (f"{prefix}HCC{hcc}".lower(), model_name)
+        # For RxHCC models, use RXHCC prefix instead of HCC
+        if 'RxHCC' in model_name:
+            key = (f"{prefix}RXHCC{hcc}".lower(), model_name)
+        else:
+            key = (f"{prefix}HCC{hcc}".lower(), model_name)
 
         if key in coefficients:
             value = coefficients[key]


### PR DESCRIPTION
The hccinfhir library constructed incorrect lookup keys for RxHCC models in apply_coefficients()

`# Apply the coefficients
for hcc in hcc_set:
    key = (f"{prefix}HCC{hcc}".lower(), model_name)  # ❌ Always used "HCC"
    if key in coefficients:
        value = coefficients[key]
        output[hcc] = value`

**Why it failed**

**For RxHCC Model V08, the library constructed keys like:**
_('rx_ce_lowaged_hcc311', 'RxHCC Model V08')
('rx_ce_lowaged_hcc20', 'RxHCC Model V08')_

**But the coefficient file (ra_coefficients_2026.csv) uses "RXHCC" in the keys:**
_Rx_CE_LowAged_RXHCC311,0.191,RxHCC,R08
Rx_CE_LowAged_RXHCC20,0.921,RxHCC,R08_

**Result: Lookups failed because:**
_Library looked for: rx_ce_lowaged_hcc311
Actual key in file: rx_ce_lowaged_rxhcc311_

**Mismatch** → No coefficient found → None → Disease score = 0

**The fix**

`# Apply the coefficientsfor hcc in hcc_set:    # For RxHCC models, use RXHCC prefix instead of HCC    if 'RxHCC' in model_name:        key = (f"{prefix}RXHCC{hcc}".lower(), model_name)  # ✅ Use "RXHCC" for RxHCC models    else:        key = (f"{prefix}HCC{hcc}".lower(), model_name)    # ✅ Use "HCC" for CMS-HCC models    if key in coefficients:        value = coefficients[key]        output[hcc] = value`

**What changed**

**Added a model check**: _if 'RxHCC' in model_name:_
**For RxHCC models**: use RXHCC in the key → _rx_ce_lowaged_rxhcc311_
**For CMS-HCC models**: use HCC in the key → _cna_hcc311_