### PR TITLE
fix: correct placeholder URL and duplicate section number in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ print(result.hcc_list)
 - **Features**: FHIR-native extraction, standardized data model
 - **Output**: Service-level analysis with risk adjustment calculations
 
-### 4. **Direct Diagnosis Codes**
+### 5. **Direct Diagnosis Codes**
 - **Input**: ICD-10 diagnosis codes + demographics
 - **Use Case**: Quick validation, research, prospective risk scoring
 - **Features**: No claims data needed, fast calculation
@@ -148,7 +148,7 @@ pip install hccinfhir
 
 ### Development Installation
 ```bash
-git clone https://github.com/yourusername/hccinfhir.git
+git clone https://github.com/mimilabs/hccinfhir.git
 cd hccinfhir
 pip install -e .
 ```


### PR DESCRIPTION
## Changes

1. **Placeholder URL** — The Development Installation section had `yourusername` instead of `mimilabs` in the git clone URL (line 151)
2. **Duplicate section number** — The "Data Sources & Use Cases" section had two `### 4.` headings. Renumbered "Direct Diagnosis Codes" to `### 5.`

Both are minor documentation fixes. No code changes.